### PR TITLE
chore: update rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,8 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.2.9)
+      strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
@@ -252,6 +253,7 @@ GEM
       clamp (~> 1.3)
       nokogiri (>= 1.13.9)
       xcodeproj (~> 1.21)
+    strscan (3.1.8)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)


### PR DESCRIPTION
### Why?
To patch REXML and address security vulnerabilities affecting version 3.2.6.

### Changes
- Update `rexml` from 3.2.6 to 3.2.9 in `Gemfile.lock`
- Add `strscan` as a transitive dependency